### PR TITLE
small change to ensure compilation with ghc 7.8 also works

### DIFF
--- a/tools/HatMake.hs
+++ b/tools/HatMake.hs
@@ -19,7 +19,8 @@ main = do x <- getArgs
           let opts = init x
           let optStr = concat (intersperse " " opts)
           let y = last x
-          systemTry $ "ghc -M -dep-makefile .depend " ++ y ++ " " ++ optStr
+          systemTry $ "ghc -M -dep-makefile .depend -dep-suffix \"\" " 
+                      ++ y ++ " " ++ optStr
           mak <- readFile ".depend"
           let (files,depends) = parseMakefile mak
           translate hatFolder files depends


### PR DESCRIPTION
Hi Olaf,

I noticed this morning that ghc requires at least one -dep-suffix option with -M in version 7.8, to retain the behaviour we had before an empty string is given as argument to dep-suffix. The ghc documentation is not terrible clear about this but several other projects seem to have added the same option.

Maarten