### PR TITLE
Add #include <stdint.h> to ntohl.h to make it compile on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ libraries/Hat
 *~
 *.[oa]
 *.hi
+.cabal-sandbox/
+cabal.sandbox.config

--- a/include/ntohl.h
+++ b/include/ntohl.h
@@ -2,6 +2,7 @@
 #if defined(WIN32)
 
 /* Windows does not have ntohl, so define it here */
+#include <stdint.h>
 #define htonl(x) ntohl(x)
 uint32_t ntohl(uint32_t x);
 


### PR DESCRIPTION
.gitignore is updated to ignore sandbox files
