### PR TITLE
Fixed compilation error

### DIFF
--- a/tools/PrettyLibHighlight.hs
+++ b/tools/PrettyLibHighlight.hs
@@ -28,6 +28,7 @@ module PrettyLibHighlight
   , pretty,simple
   ) where
 
+import Prelude hiding ((<>))
 import HighlightStyle (highlightOn,highlightOff,Highlight(..))
 
 


### PR DESCRIPTION
Compiled using the stack
```
Version 2.3.1, Git revision de2a7b694f07de7e6cf17f8c92338c16286b2878 (dirty) (8103 commits) x86_64
Compiled with:
- Cabal-3.2.0.0
- ...
```
Error message
```
.../hat-2.9.4/tools/PrettyLibHighlight.hs:86:23: error:
    Ambiguous occurrence ‘<>’
    It could refer to
       either ‘Prelude.<>’,
              imported from ‘Prelude’ at tools/PrettyLibHighlight.hs:24:8-25
              (and originally defined in ‘GHC.Base’)
           or ‘PrettyLibHighlight.<>’,
              defined at tools/PrettyLibHighlight.hs:43:1
   |
86 | parens doc = text "(" <> doc <> text ")"
   |                       ^^

.../hat-2.9.4/tools/PrettyLibHighlight.hs:86:30: error:
    Ambiguous occurrence ‘<>’
    It could refer to
       either ‘Prelude.<>’,
              imported from ‘Prelude’ at tools/PrettyLibHighlight.hs:24:8-25
              (and originally defined in ‘GHC.Base’)
           or ‘PrettyLibHighlight.<>’,
              defined at tools/PrettyLibHighlight.hs:43:1
   |
86 | parens doc = text "(" <> doc <> text ")"
   |                              ^^

.../hat-2.9.4/tools/PrettyLibHighlight.hs:89:25: error:
    Ambiguous occurrence ‘<>’
    It could refer to
       either ‘Prelude.<>’,
              imported from ‘Prelude’ at tools/PrettyLibHighlight.hs:24:8-25
              (and originally defined in ‘GHC.Base’)
           or ‘PrettyLibHighlight.<>’,
              defined at tools/PrettyLibHighlight.hs:43:1
   |
89 | brackets doc = text "[" <> doc <> text "]"
   |                         ^^

.../hat-2.9.4/tools/PrettyLibHighlight.hs:89:32: error:
    Ambiguous occurrence ‘<>’
    It could refer to
       either ‘Prelude.<>’,
              imported from ‘Prelude’ at tools/PrettyLibHighlight.hs:24:8-25
              (and originally defined in ‘GHC.Base’)
           or ‘PrettyLibHighlight.<>’,
              defined at tools/PrettyLibHighlight.hs:43:1
   |
89 | brackets doc = text "[" <> doc <> text "]"
   |                                ^^

.../hat-2.9.4/tools/PrettyLibHighlight.hs:92:23: error:
    Ambiguous occurrence ‘<>’
    It could refer to
       either ‘Prelude.<>’,
              imported from ‘Prelude’ at tools/PrettyLibHighlight.hs:24:8-25
              (and originally defined in ‘GHC.Base’)
           or ‘PrettyLibHighlight.<>’,
              defined at tools/PrettyLibHighlight.hs:43:1
   |
92 | braces doc = text "{" <> doc <> text "}"
   |                       ^^

.../hat-2.9.4/tools/PrettyLibHighlight.hs:92:30: error:
    Ambiguous occurrence ‘<>’
    It could refer to
       either ‘Prelude.<>’,
              imported from ‘Prelude’ at tools/PrettyLibHighlight.hs:24:8-25
              (and originally defined in ‘GHC.Base’)
           or ‘PrettyLibHighlight.<>’,
              defined at tools/PrettyLibHighlight.hs:43:1
   |
92 | braces doc = text "{" <> doc <> text "}"
   |                              ^^
```
Fixed by excluding `<>` from Prelude import.